### PR TITLE
v1.1.0: Downgrade py3 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(
     packages=find_packages(include=['background_removal', 'background_removal.*']),
     install_requires=requirements,
     package_data={"":["MODELS/*.h5"]},
-    python_requires=">=3.7.5"
+    python_requires=">=3.7.3"
 )


### PR DESCRIPTION
Downgrade py3 requirement from 3.7.5 to 3.7.3. This is for rodan team
to install paco in the new py3 rodan-main container.